### PR TITLE
feat(git): Adds in git track/untrack aliases and branch sorting override

### DIFF
--- a/common/gitconfig.symlink
+++ b/common/gitconfig.symlink
@@ -9,3 +9,8 @@
 [core]
 	editor = vim
 	pager = diff-so-fancy | less --tabs=4 -RFX
+[branch]
+    sort = committerdate
+[alias]
+    track = update-index --no-skip-worktree
+    untrack = update-index --skip-worktree


### PR DESCRIPTION
## Fixlog
- Fixes #4

## Changelog
- Adds in `git track FILENAME` alias
- Adds in `git untrack FILENAME` alias
- Sets default `git branch` sorting to be by `git branch --sort=committerdate`